### PR TITLE
Feature branch - Better skater tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A simple table scraper from the AHL daily reports page written for R programmers
  
 This is a work in progress. Please use the Issues tab to call out specific needs.
 
-Upcoming features: Remove hard-coded references, clean and consolidate tables that include skaters' multiple teams, team-based data frames for skaters and goalies, league-level scraping, data visualizations
+Upcoming features: Remove hard-coded references, team-based data frames for skaters and goalies, league-level scraping, data visualizations
 
 ## Getting Started
 Running this R script will load the required packages and create a set of functions for scraping the AHL daily reports page. There is no barrier to entry, provided you have all prerequisites installed.
@@ -16,20 +16,22 @@ install.packages("rvest")
 install.packages("stringr")
 ```
 
-## Example
-View all teams and the index of their table
+## Functions
+**ListTables** will show all teams and the index of their table. It takes no arguments.
 ```
 > ListTables()
 ```
 
 
-Download Texas Stars skater data, then see Tanner Kero's stats
+**fnAhlTable** is the core function for downloading tables. It takes two arguments: the table number (as _tablenum_ defaulting to 87 for the Texas Stars skaters), and whether it should clean it as a skater table (as _cleanSkaters_ defaulting to TRUE)
+
+Example: Download Texas Stars skater data, then see Tanner Kero's stats
 ```
-> txSkaters <- fnAhlTable(87)
+> txSkaters <- fnAhlTable(tablenum = 87, cleanSkaters = TRUE)
 > txSkaters[txSkaters$PLAYER == "Tanner Kero",]
 
-  No.      PLAYER POS GP G  A PTS +/- PIM PP PPA SHG SHA GW FG IG OT UA EN SOG SOA SGW  SO% SH  SH%
-4  20 Tanner Kero   C 34 7 19  26  -9  16  2   8   0   0  0  2  1  0  1  1   2   7   2 28.6 68 10.3
+  No.      PLAYER POS GP G  A PTS +/- PIM PP PPA SHG SHA GW FG IG OT UA EN SOG SOA SGW SO% SH SH% Rookie Active
+4  20 Tanner Kero   C 39 7 21  28 -11  18  2   9   0   0  0  2  1  0  1  1   2   8   2  25 84 8.3  FALSE   TRUE
 ```
 
 ## Acknowledgements

--- a/ahl_functions.R
+++ b/ahl_functions.R
@@ -11,13 +11,29 @@ url_dailyreport <- "http://admin.leaguestat.com/download.php?client_code=ahl&fil
 # Function for retrieving specific table by number from xpath
 # Input param tablenum: the number of the table from the xpath
 # Default value 87 will retrieve Texas Stars skater stats
-fnAhlTable <- function(tablenum = 87) {
+fnAhlTable <- function(tablenum = 87, cleanSkaters = TRUE) {
   xpathnum = paste('/html/body/table[',as.character(tablenum),']', sep = "")
   table_return <- url_dailyreport %>%
     read_html() %>%
     html_nodes(xpath = xpathnum) %>%
     html_table()
-  table_return[[1]]
+  df_Table <- table_return[[1]]
+  
+  if (cleanSkaters == TRUE) {
+  # Consolidate multiple teams onto only total line
+  df_Table <- df_Table %>%
+    filter(No. != "NA") %>%
+    # Remove goalies and total
+    filter(POS != "G")
+  # Add designation for Rookie
+  df_Table$Rookie <- str_detect(df_Table$PLAYER, "\\*")
+  # Add designation for Active
+  df_Table$Active <- !str_detect(df_Table$PLAYER, "^(x )|^(\\*x )")
+  # Clean names
+  df_Table$PLAYER <- str_replace_all(df_Table$PLAYER, "^(x )|^(\\*x )|^\\* |\\(total\\)$", "")
+  } else {}
+  df_Table
+  
 }
 
 ListTables <- function() {


### PR DESCRIPTION
This branch adds functionality to fnAhlTable for cleaning up skater tables by removing goalies and total lines, cleaning names, designating active, designating rookies, and updating the README appropriately to reflect this.